### PR TITLE
Fix: Injecting dependencies into app.ts errors

### DIFF
--- a/app-min/src/main.ext
+++ b/app-min/src/main.ext
@@ -9,6 +9,6 @@ new Aurelia()
   .register(BasicConfiguration, DebugConfiguration)
   .app({
     host: document.querySelector('app'),
-    component: new App()
+    component: App
   })
   .start();


### PR DESCRIPTION
I created an aurelia project:
` npx makes aurelia new-project-name -s typescript`

When I add dependencies to my app.ts 
`@inject(EventAggregator)
export class App {}`

I got the error below:
![image](https://user-images.githubusercontent.com/3967506/63815527-0ac69600-c989-11e9-88f6-8fbbb2e86224.png)

I believe this should not cause an error. This pull request removes the error while keeping the functionality working.
