### PR TITLE
feat: Use sass rather than node-sass

### DIFF
--- a/dumber/gulpfile.js
+++ b/dumber/gulpfile.js
@@ -23,6 +23,7 @@ const less = require('gulp-less');
 // @endif
 // @if sass
 const sass = require('gulp-sass');
+sass.compiler = require('sass');
 // @endif
 const postcss = require('gulp-postcss');
 const autoprefixer = require('autoprefixer');

--- a/dumber/gulpfile.js
+++ b/dumber/gulpfile.js
@@ -22,8 +22,7 @@ const cssModule = require('gulp-dumber-css-module');
 const less = require('gulp-less');
 // @endif
 // @if sass
-const sass = require('gulp-sass');
-sass.compiler = require('sass');
+const sass = require('gulp-dart-sass');
 // @endif
 const postcss = require('gulp-postcss');
 const autoprefixer = require('autoprefixer');

--- a/dumber/package.json
+++ b/dumber/package.json
@@ -24,7 +24,7 @@
     "gulp-less": "^4.0.0",
     // @endif
     // @if sass
-    "gulp-dart-sass": "^0.9.0",
+    "gulp-dart-sass": "^1.0.0",
     // @endif
     "gulp-postcss": "^8.0.0",
     "autoprefixer": "^9.0.0",

--- a/dumber/package.json
+++ b/dumber/package.json
@@ -24,8 +24,7 @@
     "gulp-less": "^4.0.0",
     // @endif
     // @if sass
-    "gulp-sass": "^4.0.0",
-    "sass": "^1.0.0",
+    "gulp-dart-sass": "^0.9.0",
     // @endif
     "gulp-postcss": "^8.0.0",
     "autoprefixer": "^9.0.0",

--- a/dumber/package.json
+++ b/dumber/package.json
@@ -25,7 +25,7 @@
     // @endif
     // @if sass
     "gulp-sass": "^4.0.0",
-    "node-sass": "^4.0.0",
+    "sass": "^1.0.0",
     // @endif
     "gulp-postcss": "^8.0.0",
     "autoprefixer": "^9.0.0",

--- a/webpack/package.json
+++ b/webpack/package.json
@@ -24,7 +24,7 @@
     // @endif
     // @if sass
     "sass-loader": "^8.0.0",
-    "node-sass": "^4.0.0",
+    "sass": "^1.0.0",
     // @endif
     "postcss-loader": "^3.0.0",
     "autoprefixer": "^9.0.0",


### PR DESCRIPTION
`node-sass` will fail to install when:
- Platforms where pre-built binaries are not supplied 
- Build from source fails due to missing native build tools or no Python 2 

Even with Python 2 and build tools installed, building `node-sass` from source takes minutes on a Raspberry Pi 4.

For our large project there is no noticeable speed difference when using `sass` instead of `node-sass` and `sass-loader` picks it up automatically.