### PR TITLE
fix(app-with-router): change goto syntax to load syntax

### DIFF
--- a/app-with-router/src/my-app.css__if_css
+++ b/app-with-router/src/my-app.css__if_css
@@ -14,12 +14,12 @@ a:hover {
 }
 
 // @if css-module
-/* When using css-module, set .goto-active
+/* When using css-module, set .load-active
 as a global class name */
-:global(.goto-active) {
+:global(.load-active) {
 // @endif
 // @if !css-module
-.goto-active {
+.load-active {
 // @endif
   background-color: lightgray;
 }

--- a/app-with-router/src/my-app.html
+++ b/app-with-router/src/my-app.html
@@ -3,8 +3,8 @@
 <import from="./missing"></import>
 
 <nav>
-  <a goto="welcome">Welcome</a>
-  <a goto="about">About</a>
+  <a load="welcome">Welcome</a>
+  <a load="about">About</a>
 </nav>
 
 <au-viewport default="welcome" fallback="missing"></au-viewport>

--- a/app-with-router/src/my-app.less__if_less
+++ b/app-with-router/src/my-app.less__if_less
@@ -14,12 +14,12 @@ a {
 }
 
 // @if css-module
-/* When using css-module, set .goto-active
+/* When using css-module, set .load-active
 as a global class name */
-:global(.goto-active) {
+:global(.load-active) {
 // @endif
 // @if !css-module
-.goto-active {
+.load-active {
 // @endif
   background-color: lightgray;
 }

--- a/app-with-router/src/my-app.scss__if_sass
+++ b/app-with-router/src/my-app.scss__if_sass
@@ -14,12 +14,12 @@ a {
 }
 
 // @if css-module
-/* When using css-module, set .goto-active
+/* When using css-module, set .load-active
 as a global class name */
-:global(.goto-active) {
+:global(.load-active) {
 // @endif
 // @if !css-module
-.goto-active {
+.load-active {
 // @endif
   background-color: lightgray;
 }


### PR DESCRIPTION
removes warning: utils.js:29 [Deprecated] The "goto" custom attribute has been deprecated. Please use the "load" custom attribute instead.

changed in https://github.com/aurelia/aurelia/commit/f49cca0148ada9ae851f59b70491af6c34e7bb57

