### PR TITLE
Support Yarn backward compatibility mode (node-modules) for Yarn version 2.x or higher

### DIFF
--- a/__test__/after-task.spec.js
+++ b/__test__/after-task.spec.js
@@ -6,7 +6,7 @@ ansiColors.inverse = ansiColors;
 ansiColors.underline = ansiColors;
 ansiColors.bold = ansiColors;
 
-const isAvailable = bin => bin === 'yarn';
+const isAvailable = bin => bin === 'yarn' || bin === 'pnpm';
 
 test('"after" task only prints summary in unattended mode', async t => {
   const prompts = {
@@ -79,10 +79,49 @@ test('"after" task only prints summary in unattended mode and here mode', async 
   );
 });
 
-test('"after" task installs deps, and prints summary', async t => {
+test('"after" task installs deps with npm, and prints summary', async t => {
   const prompts = {
     select(opts) {
-      t.deepEqual(opts.choices.map(c => c.value), [undefined, 'npm', 'yarn']);
+      t.deepEqual(opts.choices.map(c => c.value), [undefined, 'npm', 'yarn', 'pnpm']);
+      return 'npm';
+    }
+  };
+
+  function run(cmd, args) {
+    t.is(cmd, 'npm');
+    t.deepEqual(args, ['install']);
+  }
+
+  let printOut = '';
+  await after({
+    unattended: false,
+    here: false,
+    prompts,
+    run,
+    properties: {name: 'my-app'},
+    features: ['a', 'b'],
+    notDefaultFeatures: ['a', 'b-c'],
+    ansiColors
+  }, {
+    _isAvailable: isAvailable,
+    _log(m) {
+      printOut += m + '\n';
+    }
+  });
+
+  t.is(printOut,
+    '\nNext time, you can try to create similar project in silent mode:\n' +
+    ' npx makes aurelia new-project-name -s a,b-c \n\n' +
+    'Get Started\n' +
+    'cd my-app\n' +
+    'npm start\n\n'
+  );
+});
+
+test('"after" task installs deps with yarn, and prints summary', async t => {
+  const prompts = {
+    select(opts) {
+      t.deepEqual(opts.choices.map(c => c.value), [undefined, 'npm', 'yarn', 'pnpm']);
       return 'yarn';
     }
   };
@@ -114,7 +153,46 @@ test('"after" task installs deps, and prints summary', async t => {
     ' npx makes aurelia new-project-name -s a,b-c \n\n' +
     'Get Started\n' +
     'cd my-app\n' +
-    'npm start\n\n'
+    'yarn start\n\n'
+  );
+});
+
+test('"after" task installs deps with pnpm, and prints summary', async t => {
+  const prompts = {
+    select(opts) {
+      t.deepEqual(opts.choices.map(c => c.value), [undefined, 'npm', 'yarn', 'pnpm']);
+      return 'pnpm';
+    }
+  };
+
+  function run(cmd, args) {
+    t.is(cmd, 'pnpm');
+    t.deepEqual(args, ['install']);
+  }
+
+  let printOut = '';
+  await after({
+    unattended: false,
+    here: false,
+    prompts,
+    run,
+    properties: {name: 'my-app'},
+    features: ['a', 'b'],
+    notDefaultFeatures: ['a', 'b-c'],
+    ansiColors
+  }, {
+    _isAvailable: isAvailable,
+    _log(m) {
+      printOut += m + '\n';
+    }
+  });
+
+  t.is(printOut,
+    '\nNext time, you can try to create similar project in silent mode:\n' +
+    ' npx makes aurelia new-project-name -s a,b-c \n\n' +
+    'Get Started\n' +
+    'cd my-app\n' +
+    'pnpm start\n\n'
   );
 });
 

--- a/common/.npmrc
+++ b/common/.npmrc
@@ -1,2 +1,3 @@
 # for pnpm, use flat node_modules
 shamefully-hoist=true
+strict-peer-dependencies=false

--- a/common/.yarnrc.yml
+++ b/common/.yarnrc.yml
@@ -1,3 +1,2 @@
-# For compatibility in yarn 2
-pnpMode: loose
-pnpFallbackMode: all
+# For compatibility in yarn 2+
+nodeLinker: node-modules


### PR DESCRIPTION
This pull request addresses issue #85.

When development machine has `yarn` version 2.x or higher installed (current version at the moment is 3.x), after developer chooses to install `npm` dependencies using `yarn`, `yarn` works in [Plug'n'Play](https://yarnpkg.com/features/pnp) mode. This means that no `node_modules` folder in created and all `npm` packages are stored in `.yarn` folder unpacked, in original `zip` format.

1. This means that command `npm start` written in "Getting started" tip does not work. `yarn start` is printed now, when `yarn` was picked as package manager. 
2. ~~When using Visual Studio Code, for it's TypeScript language service to work Yarn's [Editor SDKs](https://yarnpkg.com/getting-started/editor-sdks) extension is needed, to make TypeScript language service (local to the folder) aware of module resolution strategy.~~
3. ~~For Parcel not to throw errors, two dev-dependencies had to be added to project's `package.json`: "@aurelia/runtime-html", "@aurelia/router" for direct-routing template and "@parcel/config-default".~~

~~Now parcel starts/builds project without throwing errors.~~

**UPDATE**:
It turned out to be a problem to make Yarn's new PnP mode work seamlessly with different IDEs and bundlers. Switching Yarn 2+ to backward compatibility mode with `nodeLinker: node-modules` option, to force it to create `node_modules` folder seems like more stable and simpler option at the moment.