### PR TITLE
fix(pnpm): add missing peer dependency to avoid warning

### DIFF
--- a/parcel/package.json
+++ b/parcel/package.json
@@ -17,6 +17,7 @@
     // @if mocha
     "process": "^0.11.10",
     // @endif
+    "@parcel/core": "^2.6.0",
     "@parcel/transformer-inline-string": "^2.6.0",
     "parcel": "^2.6.0"
   },


### PR DESCRIPTION
`"@parcel/core": "^2.6.0"` package has been added to `parcel/package.json`, to avoid following warning when installing npm packages using `pnpm`:

```batch
 WARN  Issues with peer dependencies found
.
└─┬ @aurelia/parcel-transformer 2.0.0-alpha.41
  └─┬ @parcel/plugin 2.8.0
    └─┬ @parcel/types 2.8.0
      └─┬ @parcel/cache 2.8.0
        ├── ✕ missing peer @parcel/core@^2.8.0
        └─┬ @parcel/fs 2.8.0
          ├── ✕ missing peer @parcel/core@^2.8.0
          └─┬ @parcel/types 2.8.0
            └─┬ @parcel/package-manager 2.8.0
              ├── ✕ missing peer @parcel/core@^2.8.0
              └─┬ @parcel/fs 2.8.0
                ├── ✕ missing peer @parcel/core@^2.8.0
                └─┬ @parcel/workers 2.8.0
                  └── ✕ missing peer @parcel/core@^2.8.0
Peer dependencies that should be installed:
  @parcel/core@">=2.8.0 <3.0.0"
```