### PR TITLE
feat(pnpm): better way to handle peer dependencies

### DIFF
--- a/common/.npmrc
+++ b/common/.npmrc
@@ -1,3 +1,3 @@
 # for pnpm, use flat node_modules
 shamefully-hoist=true
-strict-peer-dependencies=false
+auto-install-peers=true

--- a/parcel/package.json
+++ b/parcel/package.json
@@ -17,7 +17,6 @@
     // @if mocha
     "process": "^0.11.10",
     // @endif
-    "@parcel/core": "^2.6.0",
     "@parcel/transformer-inline-string": "^2.6.0",
     "parcel": "^2.6.0"
   },


### PR DESCRIPTION
@3cp

Maybe this is a better way to handle peer dependencies with `pnpm`: set `auto-install-peers=true` configuration option. With that I could remove `"@parcel/core"` from `parcel/package.json`.

I let you decide if you prefer this way, or to leave it as it is right now in the `master` branch.