### PR TITLE
fix(typescript): generate correct typing for TS project

### DIFF
--- a/common/src/resource.d.ts__if_typescript
+++ b/common/src/resource.d.ts__if_typescript
@@ -5,7 +5,10 @@ declare module '*.html' {
   export default template;
   export const dependencies: string[];
   export const containerless: boolean | undefined;
-  export const bindables: Record<string, PartialBindableDefinition>;
+  export const bindables: (
+    | string
+    | (PartialBindableDefinition & { name: string })
+  )[];
   export const shadowOptions: { mode: 'open' | 'closed' } | undefined;
   export function register(container: IContainer): void;
 }


### PR DESCRIPTION
bindables export is an array not a record, we forgot to update this together with the fix in the main repo.