### PR TITLE
feat(cli): adds storybook integration

### DIFF
--- a/__test__/questions.spec.js
+++ b/__test__/questions.spec.js
@@ -54,3 +54,41 @@ test('TailwindCSS question comes before unit testing question', t => {
   t.true(testingQuestionIndex >= 0, 'Unit testing question should exist');
   t.true(tailwindQuestionIndex < testingQuestionIndex, 'TailwindCSS question should come before unit testing question');
 });
+
+test('Storybook question is properly included', t => {
+  const storybookQuestion = questions.find(q => 
+    q.message && q.message.includes('Storybook')
+  );
+  
+  t.truthy(storybookQuestion, 'Storybook question should exist');
+  t.is(storybookQuestion.message, 'Do you want to add Storybook?');
+  t.true(Array.isArray(storybookQuestion.choices), 'Storybook question should have choices');
+  t.is(storybookQuestion.choices.length, 2, 'Storybook question should have 2 choices');
+  
+  // Check "No" option
+  const noChoice = storybookQuestion.choices[0];
+  t.is(noChoice.title, 'No');
+  t.is(noChoice.value, undefined);
+  
+  // Check "Yes" option
+  const yesChoice = storybookQuestion.choices[1];
+  t.is(yesChoice.value, 'storybook');
+  t.is(yesChoice.title, 'Yes');
+  t.truthy(yesChoice.hint);
+  t.true(yesChoice.hint.includes('Vite or Webpack'));
+  t.truthy(yesChoice.if);
+  t.is(yesChoice.if, '(app && (vite || webpack)) || (plugin && webpack)');
+});
+
+test('Storybook question comes after e2e testing question', t => {
+  const e2eQuestionIndex = questions.findIndex(q => 
+    q.message && q.message.includes('e2e test')
+  );
+  const storybookQuestionIndex = questions.findIndex(q => 
+    q.message && q.message.includes('Storybook')
+  );
+  
+  t.true(e2eQuestionIndex >= 0, 'E2E testing question should exist');
+  t.true(storybookQuestionIndex >= 0, 'Storybook question should exist');
+  t.true(storybookQuestionIndex > e2eQuestionIndex, 'Storybook question should come after e2e testing question');
+});

--- a/__test__/storybook.spec.js
+++ b/__test__/storybook.spec.js
@@ -1,0 +1,119 @@
+const test = require('ava');
+const fs = require('fs');
+const path = require('path');
+
+test('Storybook configuration files exist', t => {
+  // Check main config
+  const mainPath = path.join(__dirname, '..', 'common', 'storybook-main.ext__if_storybook');
+  t.true(fs.existsSync(mainPath), 'Storybook main config should exist');
+  
+  // Check preview config
+  const previewPath = path.join(__dirname, '..', 'common', 'storybook-preview.ext__if_storybook');
+  t.true(fs.existsSync(previewPath), 'Storybook preview config should exist');
+  
+  // Check README
+  const readmePath = path.join(__dirname, '..', 'storybook__if_storybook', 'README.md');
+  t.true(fs.existsSync(readmePath), 'Storybook README should exist');
+});
+
+test('Storybook configuration includes both Vite and Webpack setups', t => {
+  const mainPath = path.join(__dirname, '..', 'common', 'storybook-main.ext__if_storybook');
+  const content = fs.readFileSync(mainPath, 'utf8');
+  
+  t.true(content.includes('@aurelia/storybook'), 'Should use Aurelia Storybook framework');
+  t.true(content.includes('@storybook/builder-vite'), 'Should use Vite builder');
+  t.true(content.includes('@storybook/builder-webpack5'), 'Should use Webpack5 builder');
+  t.true(content.includes('@storybook/addon-links'), 'Should include links addon');
+  t.true(content.includes('viteFinal'), 'Should have viteFinal configuration');
+  t.true(content.includes('@aurelia/runtime-html'), 'Should exclude Aurelia runtime from optimization');
+  t.true(content.includes('/* @if vite */'), 'Should have Vite conditional');
+  t.true(content.includes('/* @if webpack */'), 'Should have Webpack conditional');
+});
+
+test('Storybook Webpack configuration is included', t => {
+  const mainPath = path.join(__dirname, '..', 'common', 'storybook-main.ext__if_storybook');
+  const content = fs.readFileSync(mainPath, 'utf8');
+  
+  t.true(content.includes('docs: {}'), 'Should have docs configuration');
+});
+
+test('Storybook preview configuration is correct', t => {
+  const previewPath = path.join(__dirname, '..', 'common', 'storybook-preview.ext__if_storybook');
+  const content = fs.readFileSync(previewPath, 'utf8');
+  
+  t.true(content.includes("export { render, renderToCanvas } from '@aurelia/storybook'"), 
+    'Should export render functions from Aurelia Storybook plugin');
+});
+
+test('Storybook story files exist and are properly structured', t => {
+  // Check app-min story file
+  const appMinStoryPath = path.join(__dirname, '..', 'app-min', 'src', 'my-app.stories.ext__if_storybook');
+  t.true(fs.existsSync(appMinStoryPath), 'App-min story file should exist');
+  
+  const appMinContent = fs.readFileSync(appMinStoryPath, 'utf8');
+  t.true(appMinContent.includes('/* @if vite */'), 'Should have Vite conditional');
+  t.true(appMinContent.includes('/* @if webpack */'), 'Should have Webpack conditional');
+  t.true(appMinContent.includes('import { MyApp }'), 'Should import MyApp component');
+  
+  // Check app-with-router story file
+  const routerStoryPath = path.join(__dirname, '..', 'app-with-router', 'src', 'welcome-page.stories.ext__if_storybook');
+  t.true(fs.existsSync(routerStoryPath), 'Router app story file should exist');
+  
+  // Check plugin story file
+  const pluginStoryPath = path.join(__dirname, '..', 'plugin-min', 'src', 'hello-world.stories.ext__if_storybook');
+  t.true(fs.existsSync(pluginStoryPath), 'Plugin story file should exist');
+});
+
+test('Vite package.json includes correct Storybook dependencies', t => {
+  const vitePackagePath = path.join(__dirname, '..', 'vite', 'package.json');
+  const content = fs.readFileSync(vitePackagePath, 'utf8');
+  
+  t.true(content.includes('"@aurelia/storybook": "^1.0.2"'), 'Should include Aurelia Storybook plugin v1.0.2');
+  t.true(content.includes('"storybook": "^9.0.0"'), 'Should include Storybook 9');
+  t.true(content.includes('"@storybook/builder-vite": "^9.0.0"'), 'Should include Vite builder');
+  t.true(content.includes('"@storybook/addon-links": "^9.0.0"'), 'Should include links addon');
+  t.true(content.includes('"@storybook/addon-actions": "^9.0.0"'), 'Should include actions addon');
+  t.true(content.includes('"@storybook/test": "^9.0.0-alpha.2"'), 'Should include test utilities');
+  
+  // Check scripts
+  t.true(content.includes('"storybook": "storybook dev -p 6006"'), 'Should include storybook dev script');
+  t.true(content.includes('"build-storybook": "storybook build"'), 'Should include build script');
+});
+
+test('Webpack package.json includes correct Storybook dependencies', t => {
+  const webpackPackagePath = path.join(__dirname, '..', 'webpack', 'package.json');
+  const content = fs.readFileSync(webpackPackagePath, 'utf8');
+  
+  t.true(content.includes('"@aurelia/storybook": "^1.0.2"'), 'Should include Aurelia Storybook plugin v1.0.2');
+  t.true(content.includes('"storybook": "^9.0.0"'), 'Should include Storybook 9');
+  t.true(content.includes('"@storybook/builder-webpack5": "^9.0.0"'), 'Should include Webpack5 builder');
+  t.true(content.includes('"@storybook/addon-links": "^9.0.0"'), 'Should include links addon');
+  
+  // Check scripts
+  t.true(content.includes('"storybook": "storybook dev -p 6006"'), 'Should include storybook dev script');
+  t.true(content.includes('"build-storybook": "storybook build"'), 'Should include build script');
+});
+
+test('Storybook README contains helpful information', t => {
+  const readmePath = path.join(__dirname, '..', 'storybook__if_storybook', 'README.md');
+  const content = fs.readFileSync(readmePath, 'utf8');
+  
+  t.true(content.includes('# Storybook Integration'), 'Should have main heading');
+  t.true(content.includes('npm run storybook'), 'Should include dev command');
+  t.true(content.includes('npm run build-storybook'), 'Should include build command');
+  t.true(content.includes('http://localhost:6006'), 'Should mention default port');
+  t.true(content.includes('.stories.ts'), 'Should explain story file naming');
+  t.true(content.includes('Aurelia Storybook'), 'Should reference the plugin');
+});
+
+test('After task includes Storybook setup logic', t => {
+  const afterPath = path.join(__dirname, '..', 'after.js');
+  const content = fs.readFileSync(afterPath, 'utf8');
+  
+  t.true(content.includes("if (features.includes('storybook'))"), 'Should check for storybook feature');
+  t.true(content.includes("fs.mkdirSync('.storybook')"), 'Should create .storybook directory');
+  t.true(content.includes('storybook-main'), 'Should reference storybook-main file');
+  t.true(content.includes('storybook-preview'), 'Should reference storybook-preview file');
+  t.true(content.includes('.storybook/main'), 'Should move to .storybook/main');
+  t.true(content.includes('.storybook/preview'), 'Should move to .storybook/preview');
+}); 

--- a/app-min/src/my-app.stories.ext__if_storybook
+++ b/app-min/src/my-app.stories.ext__if_storybook
@@ -1,7 +1,7 @@
 /* @if vite */
 import { MyApp } from './my-app';
-import { action } from '@storybook/addon-actions';
-import { userEvent, within } from '@storybook/test';
+//import { action } from '@storybook/addon-actions';
+//import { userEvent, within } from '@storybook/test';
 
 const meta = {
   title: 'Example/MyApp',

--- a/app-min/src/my-app.stories.ext__if_storybook
+++ b/app-min/src/my-app.stories.ext__if_storybook
@@ -1,0 +1,56 @@
+/* @if vite */
+import { MyApp } from './my-app';
+import { action } from '@storybook/addon-actions';
+import { userEvent, within } from '@storybook/test';
+
+const meta = {
+  title: 'Example/MyApp',
+  component: MyApp,
+  render: () => ({
+    template: `<my-app message.bind="message"></my-app>`,
+  }),
+  argTypes: {
+    message: { control: 'text' }
+  }
+};
+
+export default meta;
+
+export const Default = {
+  args: {
+    message: 'Hello from Storybook!'
+  }
+};
+
+export const CustomMessage = {
+  args: {
+    message: 'This is a custom message for testing'
+  }
+};
+
+export const WelcomeMessage = {
+  args: {
+    message: 'Welcome to your Aurelia 2 + Storybook setup!'
+  }
+};
+
+export const NoArgs = {
+  render: () => ({
+    template: `<my-app></my-app>`
+  })
+};
+/* @endif */
+/* @if webpack */
+import { MyApp } from './my-app';
+
+export default {
+  title: 'MyApp',
+  component: MyApp,
+};
+
+export const Default = () => ({
+  Component: MyApp,
+  template: '<my-app></my-app>',
+  props: {}
+});
+/* @endif */ 

--- a/app-with-router/src/welcome-page.stories.ext__if_storybook
+++ b/app-with-router/src/welcome-page.stories.ext__if_storybook
@@ -1,0 +1,54 @@
+/* @if vite */
+import { WelcomePage } from './welcome-page';
+
+const meta = {
+  title: 'Pages/WelcomePage',
+  component: WelcomePage,
+  render: () => ({
+    template: `<welcome-page message.bind="message"></welcome-page>`,
+  }),
+  argTypes: {
+    message: { control: 'text' }
+  }
+};
+
+export default meta;
+
+export const Default = {
+  args: {
+    message: 'Welcome to Aurelia 2!'
+  }
+};
+
+export const CustomWelcome = {
+  args: {
+    message: 'Welcome to your amazing Aurelia app!'
+  }
+};
+
+export const StorybookWelcome = {
+  args: {
+    message: 'Welcome to Storybook + Aurelia 2!'
+  }
+};
+
+export const LongMessage = {
+  args: {
+    message: 'Welcome to this comprehensive demonstration of Aurelia 2 components in Storybook!'
+  }
+};
+/* @endif */
+/* @if webpack */
+import { WelcomePage } from './welcome-page';
+
+export default {
+  title: 'WelcomePage',
+  component: WelcomePage,
+};
+
+export const Default = () => ({
+  Component: WelcomePage,
+  template: '<welcome-page></welcome-page>',
+  props: {}
+});
+/* @endif */ 

--- a/common/storybook-main.ext__if_storybook
+++ b/common/storybook-main.ext__if_storybook
@@ -1,0 +1,48 @@
+/* @if vite */
+import type { StorybookConfig } from 'storybook/internal/types';
+import { mergeConfig, type InlineConfig } from 'vite';
+
+const config: StorybookConfig & { viteFinal?: (config: InlineConfig, options: { configType: string }) => InlineConfig | Promise<InlineConfig> } = {
+  stories: ['../src/**/*.stories.@(ts|tsx|js|jsx|mdx)'],
+  addons: [
+    '@storybook/addon-links'
+  ],
+  framework: {
+    name: '@aurelia/storybook',
+    options: {},
+  },
+  core: {
+    builder: '@storybook/builder-vite',
+  },
+  viteFinal: async (viteConfig) => {
+    viteConfig.optimizeDeps = viteConfig.optimizeDeps || {};
+    viteConfig.optimizeDeps.exclude = viteConfig.optimizeDeps.exclude || [];
+    if (!viteConfig.optimizeDeps.exclude.includes('@aurelia/runtime-html')) {
+      viteConfig.optimizeDeps.exclude.push('@aurelia/runtime-html');
+    }
+    return mergeConfig(viteConfig, {
+      // ...any additional Vite configuration
+    });
+  },
+};
+
+export default config;
+/* @endif */
+/* @if webpack */
+const config = {
+  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  addons: [
+    "@storybook/addon-links"
+  ],
+  framework: {
+    name: '@aurelia/storybook',
+    options: {},
+  },
+  core: {
+    builder: '@storybook/builder-webpack5',
+  },
+  docs: {},
+};
+
+export default config;
+/* @endif */ 

--- a/common/storybook-preview.ext__if_storybook
+++ b/common/storybook-preview.ext__if_storybook
@@ -1,0 +1,2 @@
+// Import the render function from the Aurelia Storybook plugin
+export { render, renderToCanvas } from '@aurelia/storybook'; 

--- a/plugin-min/src/hello-world.stories.ext__if_storybook
+++ b/plugin-min/src/hello-world.stories.ext__if_storybook
@@ -1,0 +1,46 @@
+import { HelloWorld } from './hello-world';
+import { action } from '@storybook/addon-actions';
+import { userEvent, within } from '@storybook/test';
+
+const meta = {
+  title: 'Plugin/HelloWorld',
+  component: HelloWorld,
+  render: () => ({
+    template: `<hello-world message.bind="message"></hello-world>`,
+  }),
+  argTypes: {
+    message: { control: 'text' }
+  }
+};
+
+export default meta;
+
+export const Default = {
+  args: {
+    message: 'Hello from your Aurelia plugin!'
+  }
+};
+
+export const Empty = {
+  args: {
+    message: ''
+  }
+};
+
+export const LongMessage = {
+  args: {
+    message: 'This is a longer message to test how the component handles more text content'
+  }
+};
+
+export const CustomStorybook = {
+  args: {
+    message: 'Testing your Aurelia plugin component in Storybook!'
+  }
+};
+
+export const NoMessage = {
+  render: () => ({
+    template: `<hello-world></hello-world>`
+  })
+}; 

--- a/questions.js
+++ b/questions.js
@@ -69,6 +69,13 @@ module.exports = [
     ]
   },
   {
+    message: 'Do you want to add Storybook?',
+    choices: [
+      {title: 'No'},
+      {if: '(app && (vite || webpack)) || (plugin && webpack)', value: 'storybook', title: 'Yes', hint: 'Add Storybook for component development and testing (requires Vite or Webpack)'}
+    ]
+  },
+  {
 
     message: 'What kind of sample code do you want in this project?',
     choices: [

--- a/storybook__if_storybook/README.md
+++ b/storybook__if_storybook/README.md
@@ -1,0 +1,58 @@
+# Storybook Integration
+
+This project includes Storybook for component development and testing. Storybook allows you to develop and test your Aurelia 2 components in isolation.
+
+## Getting Started
+
+To start Storybook in development mode, run:
+
+```bash
+npm run storybook
+```
+
+This will start Storybook on http://localhost:6006
+
+To build Storybook for production:
+
+```bash
+npm run build-storybook
+```
+
+## Writing Stories
+
+Stories are written in `.stories.ts` (or `.stories.js`) files alongside your components. Here's a basic example:
+
+```typescript
+import { MyComponent } from './my-component';
+
+const meta = {
+  title: 'Example/MyComponent',
+  component: MyComponent,
+  render: (args) => ({
+    template: `<my-component message.bind="message"></my-component>`,
+  }),
+  argTypes: {
+    message: { control: 'text' }
+  }
+};
+
+export default meta;
+
+export const Default = {
+  args: {
+    message: 'Hello World!'
+  }
+};
+```
+
+## Features
+
+- **Interactive Controls**: Use Storybook's Controls addon to dynamically change component properties
+- **Actions**: Track and display component events using the Actions addon
+- **Testing**: Write interaction tests using Storybook's testing utilities
+
+## Learn More
+
+- [Storybook Documentation](https://storybook.js.org/docs)
+- [Aurelia Storybook Integration](https://github.com/aurelia/storybook)
+- [Aurelia 2 Documentation](https://docs.aurelia.io) 

--- a/vite/package.json
+++ b/vite/package.json
@@ -21,12 +21,24 @@
     "tailwindcss": "^4.1.10",
     "@tailwindcss/vite": "^4.1.10",
     // @endif
+    // @if storybook
+    "@aurelia/storybook": "^1.0.2",
+    "storybook": "^9.0.0",
+    "@storybook/builder-vite": "^9.0.0",
+    "@storybook/addon-links": "^9.0.0",
+    "@storybook/addon-actions": "^9.0.0",
+    "@storybook/test": "^9.0.0-alpha.2",
+    // @endif
   },
   "scripts": {
     "start": "vite",
     "build": "vite build",
     // @if vitest
     "test": "vitest",
+    // @endif
+    // @if storybook
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
     // @endif
   },
   "overrides": {

--- a/webpack/package.json
+++ b/webpack/package.json
@@ -29,10 +29,20 @@
     // @if plugin
     "webpack-node-externals": "^3.0.0",
     // @endif
+    // @if storybook
+    "@aurelia/storybook": "^1.0.2",
+    "storybook": "^9.0.0",
+    "@storybook/builder-webpack5": "^9.0.0",
+    "@storybook/addon-links": "^9.0.0",
+    // @endif
   },
   "scripts": {
     "start": "webpack serve",
     "build": "webpack --env production",
     "analyze": "webpack --env production --analyze",
+    // @if storybook
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
+    // @endif
   }
 }


### PR DESCRIPTION
This includes adding necessary dependencies, configuration files, and sample stories for various project types (app-min, app-with-router, plugin-min). It also updates the after task to set up the .storybook directory and move the configuration files.

A new test suite is added to verify the correct Storybook setup. A question is added to the prompt asking users if they want to add Storybook.